### PR TITLE
Get rid of dud parachutes

### DIFF
--- a/lua/autorun/server/sv_parachute.lua
+++ b/lua/autorun/server/sv_parachute.lua
@@ -24,9 +24,10 @@ local LFS_EJECT_LAUNCH_BIAS
 local LFS_ENTER_RADIUS
 
 local allChuteSweps = CFC_Parachute.AllChuteSweps
+local isValid = IsValid
 
 local function changeOwner( wep, ply )
-    if not IsValid( wep ) then return end
+    if not isValid( wep ) then return end
     if wep:GetClass() ~= "cfc_weapon_parachute" then return end
 
     timer.Simple( 0, function()
@@ -35,7 +36,7 @@ local function changeOwner( wep, ply )
 end
 
 function CFC_Parachute.SetDesignSelection( ply, oldDesign, newDesign )
-    if not IsValid( ply ) then return end
+    if not isValid( ply ) then return end
     
     oldDesign = oldDesign or 1
     newDesign = newDesign or 1
@@ -70,7 +71,7 @@ function CFC_Parachute.SetDesignSelection( ply, oldDesign, newDesign )
 
     local wep = ply:GetWeapon( "cfc_weapon_parachute" )
 
-    if IsValid( wep ) then
+    if isValid( wep ) then
         wep:ApplyChuteDesign()
     end
 end
@@ -92,11 +93,11 @@ function CFC_Parachute.TrySetupLFS()
     end
 
     hook.Add( "PlayerLeaveVehicle", "CFC_Parachute_LFSAirEject", function( ply, vehicle )
-        if not IsValid( ply ) or not ply:IsPlayer() or not ply:Alive() or not IsValid( vehicle ) then return end
+        if not isValid( ply ) or not ply:IsPlayer() or not ply:Alive() or not isValid( vehicle ) then return end
         
         local lfsPlane = vehicle.LFSBaseEnt
 
-        if not IsValid( lfsPlane ) then return end
+        if not isValid( lfsPlane ) then return end
 
         local minHeight = LFS_AUTO_CHUTE_HEIGHT:GetFloat()
         local canAutoChute
@@ -128,7 +129,7 @@ function CFC_Parachute.TrySetupLFS()
 
         local wep = ply:GetWeapon( "cfc_weapon_parachute" )
 
-        if not IsValid( wep ) then
+        if not isValid( wep ) then
             wep = ents.Create( "cfc_weapon_parachute" )
             wep:SetPos( Vector( 0, 0, 0 ) )
             wep:SetOwner( ply )
@@ -176,9 +177,9 @@ function CFC_Parachute.TrySetupLFS()
         end
 
         timer.Simple( 0.01, function()
-            if not IsValid( ply ) then return end
+            if not isValid( ply ) then return end
 
-            local lfsVel = IsValid( lfsPlane ) and lfsPlane:GetVelocity() * 1.2 or Vector( 0, 0, 0 )
+            local lfsVel = isValid( lfsPlane ) and lfsPlane:GetVelocity() * 1.2 or Vector( 0, 0, 0 )
 
             ply:SetVelocity( dir * force + lfsVel )
         end )
@@ -213,11 +214,11 @@ function CFC_Parachute.TrySetupLFS()
     end )
 
     hook.Add( "FindUseEntity", "CFC_Parachute_LFSEasyEnter", function( ply, ent )
-        if IsValid( ent ) or not IsValid( ply ) or not ply:IsPlayer() or ply:InVehicle() then return end
+        if isValid( ent ) or not isValid( ply ) or not ply:IsPlayer() or ply:InVehicle() then return end
 
         local wep = ply:GetWeapon( "cfc_weapon_parachute" )
 
-        if not IsValid( wep ) or not wep.chuteIsOpen then return end
+        if not isValid( wep ) or not wep.chuteIsOpen then return end
 
         local radiusSqr = LFS_ENTER_RADIUS:GetFloat() ^ 2
         local lfsPlanes = ents.FindByClass( "lunasflightschool_*" )
@@ -238,7 +239,7 @@ function CFC_Parachute.TrySetupLFS()
 end
 
 hook.Add( "PlayerDroppedWeapon", "CFC_Parachute_ChangeOwner", function( ply, wep )
-    if not IsValid( wep ) then return end
+    if not isValid( wep ) then return end
     if wep:GetClass() ~= "cfc_weapon_parachute" then return end
 
     wep:ChangeOpenStatus( false, ply )
@@ -254,7 +255,7 @@ hook.Add( "Think", "CFC_Parachute_ApplyChuteForces", function()
     for i = count, 1, -1 do
         local wep = allChuteSweps[i]
 
-        if IsValid( wep ) then
+        if isValid( wep ) then
             wep:ApplyChuteForces()
         else
             didRemove = true
@@ -271,7 +272,7 @@ end )
 hook.Add( "KeyPress", "CFC_Parachute_HandleKeyPress", function( ply, key )
     local wep = ply:GetWeapon( "cfc_weapon_parachute" )
 
-    if not IsValid( wep ) then return end
+    if not isValid( wep ) then return end
 
     wep:KeyPress( ply, key, true )
 end )
@@ -279,7 +280,7 @@ end )
 hook.Add( "KeyRelease", "CFC_Parachute_HandleKeyRelease", function( ply, key )
     local wep = ply:GetWeapon( "cfc_weapon_parachute" )
 
-    if not IsValid( wep ) then return end
+    if not isValid( wep ) then return end
 
     wep:KeyPress( ply, key, false )
 end )
@@ -287,7 +288,7 @@ end )
 hook.Add( "OnPlayerHitGround", "CFC_Parachute_CloseChute", function( ply )
     local wep = ply:GetWeapon( "cfc_weapon_parachute" )
 
-    if not IsValid( wep ) then return end
+    if not isValid( wep ) then return end
 
     wep:ChangeOpenStatus( false )
 end )
@@ -295,7 +296,7 @@ end )
 hook.Add( "PlayerEnteredVehicle", "CFC_Parachute_CloseChute", function( ply )
     local wep = ply:GetWeapon( "cfc_weapon_parachute" )
 
-    if not IsValid( wep ) then return end
+    if not isValid( wep ) then return end
 
     wep:ChangeOpenStatus( false )
 end )
@@ -303,15 +304,15 @@ end )
 hook.Add( "EntityFireBullets", "CFC_Parachute_UnstableShoot", function( ent, data )
     local owner = ent:GetOwner()
 
-    if not IsValid( owner ) then
+    if not isValid( owner ) then
         owner = data.Attacker
     end
 
-    if not IsValid( owner ) or not owner:IsPlayer() then return end
+    if not isValid( owner ) or not owner:IsPlayer() then return end
 
     local chuteSwep = owner:GetWeapon( "cfc_weapon_parachute" )
 
-    if not IsValid( chuteSwep ) or not chuteSwep.chuteIsUnstable then return end
+    if not isValid( chuteSwep ) or not chuteSwep.chuteIsUnstable then return end
 
     if not UNSTABLE_SHOOT_LURCH_CHANCE or not UNSTABLE_SHOOT_DIRECTION_CHANGE_CHANCE then
         UNSTABLE_SHOOT_LURCH_CHANCE = GetConVar( "cfc_parachute_destabilize_shoot_lurch_chance" )
@@ -366,7 +367,7 @@ hook.Add( "InitPostEntity", "CFC_Parachute_CheckOptionalDependencies", function(
 end )
 
 net.Receive( "CFC_Parachute_SelectDesign", function( _, ply )
-    if not IsValid( ply ) then return end
+    if not isValid( ply ) then return end
 
     local requestCount = ( ply.cfcParachuteDesignRequests or 0 ) + 1
 
@@ -374,7 +375,7 @@ net.Receive( "CFC_Parachute_SelectDesign", function( _, ply )
 
     if requestCount == 1 then
         timer.Simple( DESIGN_REQUEST_BURST_DURATION, function()
-            if not IsValid( ply ) then return end
+            if not isValid( ply ) then return end
 
             ply.cfcParachuteDesignRequests = nil
         end )

--- a/lua/autorun/server/sv_parachute.lua
+++ b/lua/autorun/server/sv_parachute.lua
@@ -249,13 +249,22 @@ hook.Add( "WeaponEquip", "CFC_Parachute_ChangeOwner", changeOwner )
 
 hook.Add( "Think", "CFC_Parachute_ApplyChuteForces", function()
     local count = CFC_Parachute.AllChuteSwepsCount
+    local didRemove = false
 
-    for i = 1, count do
+    for i = count, 1, -1 do
         local wep = allChuteSweps[i]
 
         if IsValid( wep ) then
             wep:ApplyChuteForces()
+        else
+            didRemove = true
+
+            table.remove( allChuteSweps, i )
         end
+    end
+
+    if didRemove then
+        CFC_Parachute.AllChuteSwepsCount = #allChuteSweps
     end
 end )
 

--- a/lua/autorun/server/sv_parachute.lua
+++ b/lua/autorun/server/sv_parachute.lua
@@ -1,8 +1,5 @@
 CFC_Parachute = CFC_Parachute or {}
 
-CFC_Parachute.AllChuteSwepsCount = CFC_Parachute.AllChuteSwepsCount or 0
-CFC_Parachute.AllChuteSweps = CFC_Parachute.AllChuteSweps or {}
-
 CFC_Parachute.DesignMaterials = false
 CFC_Parachute.DesignMaterialNames = false
 CFC_Parachute.DesignMaterialCount = 21 -- Default value for in case someone changes their design without anyone having spawned a parachute swep yet
@@ -23,7 +20,6 @@ local LFS_EJECT_LAUNCH_FORCE
 local LFS_EJECT_LAUNCH_BIAS
 local LFS_ENTER_RADIUS
 
-local allChuteSweps = CFC_Parachute.AllChuteSweps
 local isValid = IsValid
 
 local function changeOwner( wep, ply )
@@ -247,27 +243,6 @@ hook.Add( "PlayerDroppedWeapon", "CFC_Parachute_ChangeOwner", function( ply, wep
 end )
 
 hook.Add( "WeaponEquip", "CFC_Parachute_ChangeOwner", changeOwner )
-
-hook.Add( "Think", "CFC_Parachute_ApplyChuteForces", function()
-    local count = CFC_Parachute.AllChuteSwepsCount
-    local didRemove = false
-
-    for i = count, 1, -1 do
-        local wep = allChuteSweps[i]
-
-        if isValid( wep ) then
-            wep:ApplyChuteForces()
-        else
-            didRemove = true
-
-            table.remove( allChuteSweps, i )
-        end
-    end
-
-    if didRemove then -- In case SWEP:OnRemove() ever goes wonky or the count gets misaligned
-        CFC_Parachute.AllChuteSwepsCount = #allChuteSweps
-    end
-end )
 
 hook.Add( "KeyPress", "CFC_Parachute_HandleKeyPress", function( ply, key )
     local wep = ply:GetWeapon( "cfc_weapon_parachute" )

--- a/lua/autorun/server/sv_parachute.lua
+++ b/lua/autorun/server/sv_parachute.lua
@@ -263,7 +263,7 @@ hook.Add( "Think", "CFC_Parachute_ApplyChuteForces", function()
         end
     end
 
-    if didRemove then
+    if didRemove then -- In case SWEP:OnRemove() ever goes wonky or the count gets misaligned
         CFC_Parachute.AllChuteSwepsCount = #allChuteSweps
     end
 end )

--- a/lua/entities/cfc_parachute/init.lua
+++ b/lua/entities/cfc_parachute/init.lua
@@ -62,8 +62,8 @@ function ENT:Initialize()
     end
 
     self:SetModel( "models/cfc/parachute/chute.mdl" )
-    self:PhysicsInit( SOLID_VPHYSICS )
-    self:SetSolid( SOLID_VPHYSICS )
+    self:PhysicsInit( SOLID_NONE )
+    self:SetSolid( SOLID_NONE )
     self:DrawShadow( false )
     self:SetCollisionGroup( COLLISION_GROUP_IN_VEHICLE )
     self:SetRenderMode( RENDERMODE_TRANSCOLOR )

--- a/lua/entities/cfc_parachute/init.lua
+++ b/lua/entities/cfc_parachute/init.lua
@@ -5,6 +5,8 @@ include( "shared.lua" )
 local COLOR_SHOW = Color( 255, 255, 255, 255 )
 local COLOR_HIDE = Color( 255, 255, 255, 0 )
 
+local isValid = IsValid
+
 function ENT:Unfurl()
     self.chuteIsUnfurled = true
 
@@ -47,9 +49,9 @@ function ENT:Initialize()
 
     local owner = self.chuteOwner
 
-    if not IsValid( owner ) then
+    if not isValid( owner ) then
         timer.Simple( 0.02, function()
-            if IsValid( self.chuteOwner ) then
+            if isValid( self.chuteOwner ) then
                 self:Initialize()
 
                 return
@@ -74,7 +76,7 @@ end
 function ENT:Think()
     local wep = self.chutePack
 
-    if not IsValid( wep ) then return end
+    if not isValid( wep ) then return end
 
     wep:ApplyChuteForces()
     self:NextThink( CurTime() )

--- a/lua/entities/cfc_parachute/init.lua
+++ b/lua/entities/cfc_parachute/init.lua
@@ -45,8 +45,7 @@ function ENT:Close()
     self:SetColor( COLOR_HIDE )
 end
 
-function ENT:Initialize()  
-
+function ENT:Initialize()
     local owner = self.chuteOwner
 
     if not isValid( owner ) then

--- a/lua/entities/cfc_parachute/init.lua
+++ b/lua/entities/cfc_parachute/init.lua
@@ -70,3 +70,14 @@ function ENT:Initialize()
 
     self:PhysWake()
 end
+
+function ENT:Think()
+    local wep = self.chutePack
+
+    if not IsValid( wep ) then return end
+
+    wep:ApplyChuteForces()
+    self:NextThink( CurTime() )
+
+    return true
+end

--- a/lua/weapons/cfc_weapon_parachute/init.lua
+++ b/lua/weapons/cfc_weapon_parachute/init.lua
@@ -43,8 +43,13 @@ function SWEP:Initialize()
 end
 
 function SWEP:OnRemove()
-    CFC_Parachute.AllChuteSwepsCount = CFC_Parachute.AllChuteSwepsCount - 1
-    table.RemoveByValue( CFC_Parachute.AllChuteSweps, SWEP )
+    local allChuteSweps = CFC_Parachute.AllChuteSweps
+    local chuteInd = table.KeyFromValue( allChuteSweps, self )
+
+    if chuteInd then
+        CFC_Parachute.AllChuteSwepsCount = CFC_Parachute.AllChuteSwepsCount - 1
+        table.remove( allChuteSweps, chuteInd )
+    end
 
     timer.Remove( "CFC_Parachute_UnstableDirectionChange_" .. self:EntIndex() )
 

--- a/lua/weapons/cfc_weapon_parachute/init.lua
+++ b/lua/weapons/cfc_weapon_parachute/init.lua
@@ -23,6 +23,8 @@ local MOVE_KEYS = {
 }
 local MOVE_KEY_COUNT = #MOVE_KEYS
 
+local isValid = IsValid
+
 function SWEP:Initialize()
     self.chuteCanUnfurl = true
     self.chuteMoveForward = 0
@@ -36,7 +38,7 @@ function SWEP:Initialize()
     self:SetRenderMode( RENDERMODE_TRANSCOLOR )
 
     timer.Simple( 0.1, function()
-        if not IsValid( self ) then return end
+        if not isValid( self ) then return end
 
         self:SetHoldType( "passive" )
     end )
@@ -47,7 +49,7 @@ function SWEP:OnRemove()
 
     local owner = self:GetOwner()
 
-    if not IsValid( owner ) then return end
+    if not isValid( owner ) then return end
 
     net.Start( "CFC_Parachute_GrabChuteStraps" )
     net.WriteEntity( owner )
@@ -58,7 +60,7 @@ end
 function SWEP:SpawnChute()
     local chute = self.chuteEnt
 
-    if IsValid( chute ) then return chute end
+    if isValid( chute ) then return chute end
 
     local owner = self:GetOwner()
     local chute = ents.Create( "cfc_parachute" )
@@ -71,12 +73,12 @@ function SWEP:SpawnChute()
     chute.chuteIsUnfurled = false
     chute.chutePack = self
 
-    if IsValid( owner ) then
+    if isValid( owner ) then
         chute.chuteOwner = owner
     else
         timer.Simple( 0.01, function()
             local owner = self:GetOwner()
-            owner = IsValid( owner ) and owner
+            owner = isValid( owner ) and owner
 
             chute.chuteOwner = owner
 
@@ -103,7 +105,7 @@ function SWEP:SpawnChute()
     timer.Simple( 0.02, function()
         local owner = self:GetOwner() or chute.chuteOwner
 
-        if not IsValid( owner ) or not owner:IsPlayer() then return end
+        if not isValid( owner ) or not owner:IsPlayer() then return end
 
         local shouldBeUnfurled = owner:GetInfoNum( "cfc_parachute_unfurl_invert", 0 ) ~= 0
         chute.chuteIsUnfurled = shouldBeUnfurled
@@ -125,7 +127,7 @@ function SWEP:ApplyChuteForces()
 
     local owner = self:GetOwner() or chute.chuteOwner
 
-    if not IsValid( owner ) then return end
+    if not isValid( owner ) then return end
 
     local vel = owner:GetVelocity()
     local drag = math.max( -vel.z, 0 )
@@ -183,7 +185,7 @@ end
 function SWEP:ChangeOwner( ply )
     local chute = self:SpawnChute()
 
-    ply = IsValid( ply ) and ply
+    ply = isValid( ply ) and ply
 
     self.chuteOwner = ply
     self:SetOwner( ply )
@@ -208,7 +210,7 @@ function SWEP:ChangeOpenStatus( state, ply )
     local owner = ply or self:GetOwner() or self.chuteOwner
     local prevState = self.chuteIsOpen
 
-    if not IsValid( owner ) then return end
+    if not isValid( owner ) then return end
 
     if state == nil then
         state = not prevState
@@ -246,7 +248,7 @@ end
 function SWEP:ApplyUnstableLurch()
     local owner = self:GetOwner()
 
-    if not IsValid( owner ) or owner.cfcParachuteInstabilityImmune then return end
+    if not isValid( owner ) or owner.cfcParachuteInstabilityImmune then return end
     
     local maxLurch = UNSTABLE_MAX_LURCH:GetFloat()
     local lurchForce = -math.Rand( 0, maxLurch )
@@ -257,7 +259,7 @@ end
 function SWEP:ApplyUnstableDirectionChange()
     local owner = self:GetOwner() or self.chuteOwner
 
-    if not IsValid( owner ) or owner.cfcParachuteInstabilityImmune then return end
+    if not isValid( owner ) or owner.cfcParachuteInstabilityImmune then return end
 
     local maxChange = UNSTABLE_MAX_DIR_CHANGE:GetFloat()
     local chuteDir = self.chuteDir
@@ -296,7 +298,7 @@ function SWEP:ChangeInstabilityStatus( state )
     if state then
         local owner = self:GetOwner()
 
-        if not IsValid( owner ) then return end
+        if not isValid( owner ) then return end
 
         local eyeAngles = owner:EyeAngles()
         local eyeForward = eyeAngles:Forward()
@@ -321,7 +323,7 @@ end
 function SWEP:ApplyChuteDesign()
     local owner = self:GetOwner()
 
-    if not IsValid( owner ) then return end
+    if not isValid( owner ) then return end
 
     local chute = self:SpawnChute()
     local designID = owner.cfcParachuteDesignID or 1
@@ -359,7 +361,7 @@ function SWEP:Deploy()
 
     self:ChangeInstabilityStatus( false )
 
-    if not IsValid( owner ) then return end
+    if not isValid( owner ) then return end
     
     local state = self.chuteIsOpen
 
@@ -376,7 +378,7 @@ function SWEP:Holster()
 
     self:ChangeInstabilityStatus( true )
 
-    if not IsValid( owner ) then return true end
+    if not isValid( owner ) then return true end
     
     local state = self.chuteIsOpen
 
@@ -391,7 +393,7 @@ function SWEP:Holster()
 end
 
 function SWEP:Equip( ply )
-    if not IsValid( ply ) or not ply:IsPlayer() then return end
+    if not isValid( ply ) or not ply:IsPlayer() then return end
 
     timer.Simple( 0.1, function()
         if not ply.cfcParachuteDesignID then
@@ -411,7 +413,7 @@ function SWEP:Equip( ply )
         if not designMaterials then
             local chute = self.chuteEnt
 
-            if IsValid( chute ) then
+            if isValid( chute ) then
                 hook.Run( "CFC_Parachute_ChuteCreated", chute )
 
                 designMaterials = CFC_Parachute.DesignMaterials
@@ -497,9 +499,9 @@ end
 
 function SWEP:UpdateMoveKeys()
     local owner = self:GetOwner()
-    owner = IsValid( owner ) and owner or self.chuteOwner
+    owner = isValid( owner ) and owner or self.chuteOwner
 
-    if not IsValid( owner ) or not owner:IsPlayer() then return end
+    if not isValid( owner ) or not owner:IsPlayer() then return end
 
     if owner:GetInfoNum( "cfc_parachute_unfurl_toggle", 0 ) == 0 then
         self:KeyPress( owner, IN_JUMP, owner:KeyDown( IN_JUMP ) )

--- a/lua/weapons/cfc_weapon_parachute/init.lua
+++ b/lua/weapons/cfc_weapon_parachute/init.lua
@@ -19,7 +19,6 @@ local COLOR_SHOW = Color( 255, 255, 255, 255 )
 local COLOR_HIDE = Color( 255, 255, 255, 0 )
 
 local MOVE_KEYS = {
-    IN_JUMP,
     IN_FORWARD,
     IN_BACK,
     IN_MOVERIGHT,
@@ -517,11 +516,13 @@ function SWEP:UpdateMoveKeys()
 
     if not IsValid( owner ) or not owner:IsPlayer() then return end
 
+    if owner:GetInfoNum( "cfc_parachute_unfurl_toggle", 0 ) == 0 then
+        self:KeyPress( owner, IN_JUMP, owner:KeyDown( IN_JUMP ) )
+    end
+
     for i = 1, MOVE_KEY_COUNT do
         local moveKey = MOVE_KEYS[i]
 
-        if moveKey ~= IN_JUMP or owner:GetInfoNum( "cfc_parachute_unfurl_toggle", 0 ) == 0 then
-            self:KeyPress( owner, moveKey, owner:KeyDown( moveKey ) )
-        end
+        self:KeyPress( owner, moveKey, owner:KeyDown( moveKey ) )
     end
 end

--- a/lua/weapons/cfc_weapon_parachute/init.lua
+++ b/lua/weapons/cfc_weapon_parachute/init.lua
@@ -5,9 +5,6 @@ include( "shared.lua" )
 
 CFC_Parachute = CFC_Parachute or {}
 
-CFC_Parachute.AllChuteSwepsCount = CFC_Parachute.AllChuteSwepsCount or 0
-CFC_Parachute.AllChuteSweps = CFC_Parachute.AllChuteSweps or {}
-
 local DRAG_CUTOFF = 15 -- Don't apply drag if the value is equal to or lower than this (prevents near-infinite gliding)
 local UNSTABLE_MIN_GAP = GetConVar( "cfc_parachute_destabilize_min_gap" )
 local UNSTABLE_MAX_GAP = GetConVar( "cfc_parachute_destabilize_max_gap" )
@@ -36,11 +33,6 @@ function SWEP:Initialize()
     self.chuteIsUnstable = false
     self.chuteDir = Vector( 0, 0, 0 )
 
-    local count = CFC_Parachute.AllChuteSwepsCount + 1
-
-    CFC_Parachute.AllChuteSwepsCount = count
-    CFC_Parachute.AllChuteSweps[count] = self
-
     self:SetRenderMode( RENDERMODE_TRANSCOLOR )
 
     timer.Simple( 0.1, function()
@@ -51,14 +43,6 @@ function SWEP:Initialize()
 end
 
 function SWEP:OnRemove()
-    local allChuteSweps = CFC_Parachute.AllChuteSweps
-    local chuteInd = table.KeyFromValue( allChuteSweps, self )
-
-    if chuteInd then
-        CFC_Parachute.AllChuteSwepsCount = CFC_Parachute.AllChuteSwepsCount - 1
-        table.remove( allChuteSweps, chuteInd )
-    end
-
     timer.Remove( "CFC_Parachute_UnstableDirectionChange_" .. self:EntIndex() )
 
     local owner = self:GetOwner()
@@ -85,6 +69,7 @@ function SWEP:SpawnChute()
 
     chute.chuteIsOpen = false
     chute.chuteIsUnfurled = false
+    chute.chutePack = self
 
     if IsValid( owner ) then
         chute.chuteOwner = owner


### PR DESCRIPTION
Fixes the issue where parachutes sometimes fail to function, tracks keys that are held while the chute is being spawned in, and stops chute entities from showing up on the FPP owner indicator.