### PR TITLE
Fix error

### DIFF
--- a/lua/entities/cfc_shaped_charge/init.lua
+++ b/lua/entities/cfc_shaped_charge/init.lua
@@ -57,7 +57,7 @@ function ENT:Initialize()
     self:bombVisualsTimer()
 end
 
-function ENT:OnTakeDamage ( dmg )
+function ENT:OnTakeDamage( dmg )
     self.bombHealth = self.bombHealth - dmg:GetDamage()
     if self.bombHealth <= 0 then
         if not IsValid( self ) then return end
@@ -65,11 +65,13 @@ function ENT:OnTakeDamage ( dmg )
         local attacker = dmg:GetAttacker()
         local weaponClass = "invalid weapon"
     
-        if IsValid( attacker ) then
+        if IsValid( attacker ) and attacker:IsPlayer() then
             local weapon = attacker:GetActiveWeapon()
             if IsValid( weapon ) then
                 weaponClass = weapon:GetClass()
             end
+        else
+            weaponClass = attacker:GetClass()
         end
         mixpanelTrackEvent( "Shaped charge broken", self.bombOwner, {owner = self.bombOwner, breaker = dmg:GetAttacker(), weapon = weaponClass } )
 


### PR DESCRIPTION
Fixes:
```
addons/cfc_pvp_weapons/lua/entities/cfc_shaped_charge/init.lua:69: attempt to call method 'GetActiveWeapon' (a nil value)
   0.  GetActiveWeapon - [C]:-1
    1.  unkown - addons/cfc_pvp_weapons/lua/entities/cfc_shaped_charge/init.lua:69
```
