### PR TITLE
Make slappers absurd

### DIFF
--- a/lua/weapons/cfc_slappers/shared.lua
+++ b/lua/weapons/cfc_slappers/shared.lua
@@ -78,7 +78,7 @@ if SERVER then
     function SWEP:Think()
         local vm = self:GetOwner():GetViewModel()
 
-        if self:GetNextPrimaryFire() + self.Primary.Delay < CurTime() and vm:GetSequence() ~= 0 then
+        if self:GetNextPrimaryFire() < CurTime() and vm:GetSequence() ~= 0 then
             vm:ResetSequence( 0 )
         end
     end

--- a/lua/weapons/cfc_slappers/shared.lua
+++ b/lua/weapons/cfc_slappers/shared.lua
@@ -47,8 +47,6 @@ SWEP.NPCFilter = { "npc_monk", "npc_alyx", "npc_barney", "npc_citizen", "npc_kle
 SWEP.Mins = Vector( -8, -8, -8 )
 SWEP.Maxs = Vector( 8, 8, 8 )
 
-SWEP.Offset = Vector( 0, 0, -100 )
-
 --[[
 	Weapon Config
 ]]


### PR DESCRIPTION
Change entire damage & force setup for fast slapping.
Weapons will be dropped after "slappers_slap_weapons_consecutive" slaps are reached within 2 seconds.

Slapping the world will damage the slapper and give them a bit of velocity.

Primary, secondary fire both get individual timers, so spamming left+right click gets you the optimal slapping.

Tried restructuring all the functions relative positions in the file, bad idea, not gonna try that again.