### PR TITLE
Buff ion cannon

### DIFF
--- a/lua/weapons/cfc_ion_cannon/shared.lua
+++ b/lua/weapons/cfc_ion_cannon/shared.lua
@@ -40,6 +40,9 @@ SWEP.Primary = {
     DamageEase = math.ease.InCubic, -- Easing function to use for the damage curve
     Count = 10, -- Optional: Shots fired per unit ammo
 
+    ExtraDamageMultAtFullCharge = 1, -- Extra multiplier against bullet damage when at exsactly 100% charge.
+    ExtraDamageExplosiveMultAtFullCharge = 1.5, -- Extra multiplier against explosive damage when at exsactly 100% charge.
+
     PumpAction = false, -- Optional: Tries to pump the weapon between shots
     PumpSound = "Weapon_Shotgun.Special1", -- Optional: Sound to play when pumping
 
@@ -154,10 +157,16 @@ function SWEP:FireWeapon( chargeAmount )
     local clipMax = primary.ClipSize
     local damageFrac = primary.DamageEase( chargeAmount / clipMax )
     local damage = math.max( 1, primary.Damage * damageFrac )
+    local damageExplosive = math.floor( primary.DamageExplosive * damageFrac )
     local selfObj = self
 
     if SERVER then
         self._hasDoneFirstBullet = false
+    end
+
+    if chargeAmount == clipMax then
+        damage = damage * primary.ExtraDamageMultAtFullCharge
+        damageExplosive = damageExplosive * primary.ExtraDamageExplosiveMultAtFullCharge
     end
 
     local bullet = {
@@ -178,8 +187,6 @@ function SWEP:FireWeapon( chargeAmount )
                 if selfObj._hasDoneFirstBullet then return end
 
                 selfObj._hasDoneFirstBullet = true
-
-                local damageExplosive = math.floor( primary.DamageExplosive * damageFrac )
 
                 if damageExplosive > 0 then
                     doExplosiveDamage( selfObj, owner, tr, damageExplosive, primary.DamageExplosiveRadius * damageFrac, damageFrac )

--- a/lua/weapons/cfc_ion_cannon/shared.lua
+++ b/lua/weapons/cfc_ion_cannon/shared.lua
@@ -43,6 +43,11 @@ SWEP.Primary = {
     ExtraDamageMultAtFullCharge = 1, -- Extra multiplier against bullet damage when at exsactly 100% charge.
     ExtraDamageExplosiveMultAtFullCharge = 1.5, -- Extra multiplier against explosive damage when at exsactly 100% charge.
 
+    -- For cfc_pvp ACF damage conversion
+    ACFDamageMultMin = 1, -- Damagae multiplier against props when the distance is past ACFDamageMultRange.
+    ACFDamageMultMax = 3, -- Damagae multiplier against props when the distance is at 0.
+    ACFDamageMultRange = 1000, -- Falloff distance for the prop damage multiplier. 0 to disable.
+
     PumpAction = false, -- Optional: Tries to pump the weapon between shots
     PumpSound = "Weapon_Shotgun.Special1", -- Optional: Sound to play when pumping
 
@@ -169,6 +174,10 @@ function SWEP:FireWeapon( chargeAmount )
         damageExplosive = damageExplosive * primary.ExtraDamageExplosiveMultAtFullCharge
     end
 
+    local acfMultMin = primary.ACFDamageMultMin
+    local acfMultMax = primary.ACFDamageMultMax
+    local acfRange = primary.ACFDamageMultRange
+
     local bullet = {
         Num = primary.Count,
         Src = owner:GetShootPos(),
@@ -179,8 +188,21 @@ function SWEP:FireWeapon( chargeAmount )
         Force = damage * 0.25,
         Damage = damage,
         Callback = function( _attacker, tr, dmginfo )
-            dmginfo:ScaleDamage( self:GetDamageFalloff( tr.StartPos:Distance( tr.HitPos ) ) )
+            local dist = tr.StartPos:Distance( tr.HitPos )
+
+            dmginfo:ScaleDamage( self:GetDamageFalloff( dist ) )
             dmginfo:SetDamageType( DMG_BULLET + DMG_DISSOLVE )
+
+            -- Dynamically modify ACF_DamageMult
+            if SERVER and acfRange > 0 then
+                local acfMult = Lerp( math.Clamp( dist / acfRange, 0, 1 ), acfMultMax, acfMultMin )
+
+                -- Bullet callbacks that hit the same victim all run together, then (Post)EntityTakeDamage,
+                --  then the next group of bullet callbacks, etc.
+                -- So this will always apply to the correct damage events, in order.
+                -- This will also make the explosion's ACF damage get scaled by the first bullet, which is good.
+                self.ACF_DamageMult = acfMult
+            end
 
             -- Add explosion to the first bullet only
             if SERVER then


### PR DESCRIPTION
- When at exactly 100% charge, explosion damage receives a x1.5 multiplier.
  - Effectively changes the explosive damage at full charge from 150 to 225.
  - This is to make it easier to land aoe kills on players with a full charge.
  - Doesn't apply when overcharged (i.e. when used with an ammo powerup) as that's already overkill.
- Now has an ACF damage multiplier of x3, which falls down to x1 at a distance of 1k hmu.