### PR TITLE
Recombine damage events that get split apart by source jank

### DIFF
--- a/lua/autorun/server/cfc_bonk_gun_utils.lua
+++ b/lua/autorun/server/cfc_bonk_gun_utils.lua
@@ -375,7 +375,7 @@ function CFCPvPWeapons.CollectBonkHits( wep )
 
         hit.damage = hit.damage + dmg:GetDamage()
         hit.force = hit.force + dmgForce
-    end )
+    end, HOOK_LOW )
 end
 
 -- Should not be called manually.

--- a/lua/autorun/server/cfc_bonk_gun_utils.lua
+++ b/lua/autorun/server/cfc_bonk_gun_utils.lua
@@ -252,10 +252,6 @@ local function processDamage( attacker, victim, wep, dmg, fromGround )
             return false -- No need for a manual bonk.
         end
 
-        --local force = getBonkForce( attacker, victim, wep, dmgForce, dmgAmount, fromGround )
-
-        --bonkPlayerOrNPC( attacker, victim, wep, force )
-
         return true, fromGround, dmgForce
     end
 

--- a/lua/weapons/cfc_bonk_gun_base.lua
+++ b/lua/weapons/cfc_bonk_gun_base.lua
@@ -118,6 +118,17 @@ if CLIENT then
 end
 
 
+-- Call immediately before firing bullets.
+-- Collects separate damage events together, to fix a source bug that sometimes splits multi-bullet shots into multiple damage events.
+function SWEP:CollectBonkHits()
+    self._bonkHits = self._bonkHits or {}
+end
+
+-- Call immedaitely after firing bullets, dealing damage, etc.
+function SWEP:ApplyBonkHits()
+    CFCPvPWeapons.ApplyBonkHits( self )
+end
+
 function SWEP:FireWeapon()
     local selfForce = self.Bonk.SelfForce
     if not selfForce then return BaseClass.FireWeapon( self ) end
@@ -153,5 +164,7 @@ function SWEP:FireWeapon()
         return
     end
 
+    self:CollectBonkHits()
     BaseClass.FireWeapon( self )
+    self:ApplyBonkHits()
 end

--- a/lua/weapons/cfc_bonk_gun_base.lua
+++ b/lua/weapons/cfc_bonk_gun_base.lua
@@ -119,12 +119,12 @@ end
 
 
 -- Call immediately before firing bullets.
--- Collects separate damage events together, to fix a source bug that sometimes splits multi-bullet shots into multiple damage events.
+-- Collects separate damage events together.
 function SWEP:CollectBonkHits()
-    self._bonkHits = self._bonkHits or {}
+    CFCPvPWeapons.CollectBonkHits( self )
 end
 
--- Call immedaitely after firing bullets, dealing damage, etc.
+-- Call immediately after firing bullets, dealing damage, etc. If you delay by even one tick, it'll break things!
 function SWEP:ApplyBonkHits()
     CFCPvPWeapons.ApplyBonkHits( self )
 end


### PR DESCRIPTION
Some maps have a strange property where certain regions (everything east of a certain road in bigcity, near various buildings in nyc, etc) which causes multi-bullet weapons to have their damage events get split up into multiple damage events, even if all of them hit one target.

https://github.com/user-attachments/assets/adac1d9b-6051-4e7e-8a92-117318ba341c

Note the one vs many orange hitmarkers when hitting these two props.

Said bug causes issues with how the bonk system calculates damage, thus breaking the bonk shotgun in those areas. This PR causes damage events (per weapon per victim) to be accumulated and then processed in one go, resolving the issue.