### PR TITLE
Bonk tweaks

### DIFF
--- a/lua/autorun/client/cfc_bonk_gun_utils.lua
+++ b/lua/autorun/client/cfc_bonk_gun_utils.lua
@@ -16,3 +16,21 @@ net.Receive( "CFC_BonkGun_PlayTweakedSound", function()
         station:Play()
     end )
 end )
+
+net.Receive( "CFC_BonkGun_DisableMovement", function()
+    local endTime = net.ReadFloat()
+    local timeUntil = endTime - CurTime()
+    if timeUntil <= 0 then return end
+
+    hook.Add( "SetupMove", "CFC_BonkGun_MovementDisabled", function( _, mv, cmd )
+        mv:SetForwardSpeed( 0 )
+        mv:SetSideSpeed( 0 )
+        mv:SetUpSpeed( 0 )
+
+        cmd:ClearMovement()
+    end )
+
+    timer.Create( "CFC_BonkGun_MovementDisabled", timeUntil, 1, function()
+        hook.Remove( "SetupMove", "CFC_BonkGun_MovementDisabled" )
+    end )
+end )

--- a/lua/autorun/client/cfc_bonk_gun_utils.lua
+++ b/lua/autorun/client/cfc_bonk_gun_utils.lua
@@ -1,3 +1,104 @@
+local function curve( x )
+    local y = 1 - math.ease.OutCirc( x )
+
+    if y < 0 then return 0 end
+
+    return y
+end
+
+local function getCurvePoints( width, height, numSegments, outerUV, innerUV, moveIn )
+    width = width / 2
+    height = height / 2
+
+    local a = moveIn or 0
+    local aAlt = 1 - a
+
+    local wa = width * a
+    local ha = height * a
+    local wAlt = width * aAlt
+    local hAlt = height * aAlt
+
+    local midUV = ( innerUV + outerUV ) / 2
+
+    local x = 0
+    local y = curve( x )
+    local step = 1 / numSegments
+    local points = {
+        { x = 0, y = 0, u = outerUV, v = outerUV },
+        { x = 0, y = hAlt + ha, u = midUV, v = midUV },
+        { x = x * wAlt + wa, y = y * hAlt + ha, u = innerUV, v = innerUV },
+    }
+
+    while y > 0 do
+        x = x + step
+        y = curve( x )
+
+        table.insert( points, { x = x * wAlt + wa, y = y * hAlt + ha, u = innerUV, v = innerUV } )
+    end
+
+    table.insert( points, { x = wAlt + wa, y = 0, u = midUV, v = midUV } )
+
+    return points
+end
+
+local function makeVignettePolys( width, height, numSegments, outerUV, innerUV, moveIn )
+    local curvePoints = getCurvePoints( width, height, numSegments, outerUV, innerUV, moveIn )
+    local curvePointsReverse = table.Reverse( curvePoints )
+
+    local point1 = table.remove( curvePointsReverse, #curvePointsReverse )
+    table.insert( curvePointsReverse, 1, point1 )
+
+    local poly1 = {} -- top left (needs reverse)
+    local poly2 = {} -- top right
+    local poly3 = {} -- bottom right (needs reverse)
+    local poly4 = {} -- bottom left
+
+    for i, point in ipairs( curvePoints ) do
+        local x = point.x
+        local y = point.y
+        local u = point.u
+        local v = point.v
+
+        poly2[i] = {
+            x = width - x,
+            y = y,
+            u = u,
+            v = v
+        }
+
+        poly4[i] = {
+            x = x,
+            y = height - y,
+            u = u,
+            v = v
+        }
+    end
+
+    for i, point in ipairs( curvePointsReverse ) do
+        local x = point.x
+        local y = point.y
+        local u = point.u
+        local v = point.v
+
+        poly1[i] = {
+            x = x,
+            y = y,
+            u = u,
+            v = v,
+        }
+
+        poly3[i] = {
+            x = width - x,
+            y = height - y,
+            u = u,
+            v = v,
+        }
+    end
+
+    return { poly1, poly2, poly3, poly4 }
+end
+
+
 net.Receive( "CFC_BonkGun_PlayTweakedSound", function()
     local pos = net.ReadVector()
     local path = net.ReadString()
@@ -30,7 +131,23 @@ net.Receive( "CFC_BonkGun_DisableMovement", function()
         cmd:ClearMovement()
     end )
 
+    local numSegments = 30
+    local outerIntensity = 0.4
+    local moveIn = 0.3
+    local vignetteMat = Material( "gui/gradient_up" )
+    local polys = makeVignettePolys( ScrW(), ScrH(), numSegments, outerIntensity, 0.01, moveIn )
+
+    hook.Add( "HUDPaintBackground", "CFC_BonkGun_MovementDisabled_DrawVignette", function()
+        surface.SetDrawColor( 0, 0, 200, 150 )
+        surface.SetMaterial( vignetteMat )
+
+        for _, poly in ipairs( polys ) do
+            surface.DrawPoly( poly )
+        end
+    end )
+
     timer.Create( "CFC_BonkGun_MovementDisabled", timeUntil, 1, function()
         hook.Remove( "SetupMove", "CFC_BonkGun_MovementDisabled" )
+        hook.Remove( "HUDPaintBackground", "CFC_BonkGun_MovementDisabled_DrawVignette" )
     end )
 end )

--- a/lua/autorun/server/cfc_bonk_gun_utils.lua
+++ b/lua/autorun/server/cfc_bonk_gun_utils.lua
@@ -10,6 +10,7 @@ local hitgroupNormalizers = {} -- Used for making bonk weapons ignore hitgroup d
 local IMPACT_ACCELERATION_THRESHOLD = 7000
 local IMPACT_START_DELAY = 0.07
 local IMPACT_LIFETIME = 6
+local IMPACT_Z_MULT = 0.2
 local AIR_SHOT_REFUND_COOLDOWN = 0.01
 
 local IsValid = IsValid
@@ -381,6 +382,7 @@ local function detectImpact( ent, dt )
     local curVel = ent:GetVelocity()
     local velDiff = curVel - prevVel
     local accel = velDiff:Length() / dt
+
     bonkInfo.PrevVel = curVel
 
     if accel < IMPACT_ACCELERATION_THRESHOLD then -- Not enough acceleration to be an impact
@@ -408,6 +410,10 @@ local function detectImpact( ent, dt )
     } )
 
     if not tr.Hit then return end -- Didn't hit a wall, don't count as an impact, keep bonk status.
+
+    -- Re-calculate accel with a reduced z component when passing it on to damage, to put a focus on wall impacts and not floor impacts.
+    velDiff[3] = velDiff[3] * IMPACT_Z_MULT
+    accel = velDiff:Length() / dt
 
     handleImpact( ent, accel )
 end

--- a/lua/autorun/server/cfc_bonk_gun_utils.lua
+++ b/lua/autorun/server/cfc_bonk_gun_utils.lua
@@ -1,6 +1,7 @@
 CFCPvPWeapons = CFCPvPWeapons or {}
 
 util.AddNetworkString( "CFC_BonkGun_PlayTweakedSound" )
+util.AddNetworkString( "CFC_BonkGun_DisableMovement" )
 
 
 local bonkedEnts = {}
@@ -200,6 +201,10 @@ local function disableMovement( victim, wep )
     if not duration or duration <= 0 then return end
 
     local hookName = "CFC_BonkGun_DisableMovement_" .. victim:SteamID()
+
+    net.Start( "CFC_BonkGun_DisableMovement" )
+        net.WriteFloat( CurTime() + duration )
+    net.Send( victim )
 
     hook.Add( "SetupMove", hookName, function( ply, mv, cmd )
         if ply ~= victim then return end

--- a/lua/autorun/server/cfc_bonk_gun_utils.lua
+++ b/lua/autorun/server/cfc_bonk_gun_utils.lua
@@ -411,9 +411,13 @@ local function detectImpact( ent, dt )
 
     if not tr.Hit then return end -- Didn't hit a wall, don't count as an impact, keep bonk status.
 
-    -- Re-calculate accel with a reduced z component when passing it on to damage, to put a focus on wall impacts and not floor impacts.
-    velDiff[3] = velDiff[3] * IMPACT_Z_MULT
-    accel = velDiff:Length() / dt
+    -- Re-calculate accel with a reduced z component when passing it on to damage, to put a focus on wall/ceiling impacts and not floor impacts.
+    local velDiffZ = velDiff[3]
+
+    if velDiffZ < 0 then -- Only reduce when falling down, not when impacting a ceiling.
+        velDiff[3] = velDiffZ * IMPACT_Z_MULT
+        accel = velDiff:Length() / dt
+    end
 
     handleImpact( ent, accel )
 end

--- a/lua/weapons/cfc_bonk_shotgun/shared.lua
+++ b/lua/weapons/cfc_bonk_shotgun/shared.lua
@@ -130,14 +130,14 @@ SWEP.ViewOffset = Vector( 0, 0, 0 ) -- Optional: Applies an offset to the viewmo
 
 SWEP.Bonk = {
     Enabled = true, -- Enables bonking.
-    PlayerForce = 750 / 0.6, -- Soft-maximum launch strength for when all bullets hit, assuming no special hitgroups (e.g. only hit the chest).
+    PlayerForce = 650 / 0.6, -- Soft-maximum launch strength for when all bullets hit, assuming no special hitgroups (e.g. only hit the chest).
         PlayerForceAdd = 100, -- Flat addition to the launch strength, after the multiplier is applied.
         PlayerForceMultMax = 0.6, -- Damage mult (normal is 1) cannot exceed this value. Divide PlayerForce by this amount to make it easier to reach the max.
-        PlayerForceComboMult = 1.75, -- Multiplies against force strength if the victim is currently in a bonk state. Requires ImpactEnabled to be true.
+        PlayerForceComboMult = 1.7, -- Multiplies against force strength if the victim is currently in a bonk state. Requires ImpactEnabled to be true.
         PlayerForceGroundPitchMin = 25, -- The minimum launch pitch when on the ground.
         PlayerForceGroundZAdd = 50, -- Adds to the z-component of launch force when on the ground.
         PlayerForceGroundThreshold = 60, -- Count the victim as being grounded (minus the z-add) if they are within this many hmu of the ground.
-        PlayerForceAirMult = 1.25, -- Multiplies against force strength if the victim is in the air when hit.
+        PlayerForceAirMult = 1, -- Multiplies against force strength if the victim is in the air when hit.
         PlayerForceCounteractMult = 0.8, -- How strongly (0-1) the victim's velocity will be counteracted by the launch, if they were moving opposite to it.
         PlayerForceIgnoreThreshold = 0.2, -- If the damage multiplier is below this, the player won't be launched.
         NPCForceMult = 1.75, -- Multiplies against launch strength for NPCs.

--- a/lua/weapons/cfc_bonk_shotgun/shared.lua
+++ b/lua/weapons/cfc_bonk_shotgun/shared.lua
@@ -27,8 +27,6 @@ SWEP.CustomHoldType = {} -- Allows you to override any hold type animations with
 
 SWEP.Firemode = 0 -- The default firemode, -1 = full-auto, 0 = semi-auto, >1 = burst fire
 
-local spreadMax = 0.04
-
 SWEP.Primary = {
     Ammo = "Buckshot", -- The ammo type used when reloading
     Cost = 1, -- The amount of ammo used per shot
@@ -65,42 +63,43 @@ SWEP.Primary = {
         Sound = "" -- Optional: Sound to play when starting a reload
     },
 
-    SpreadPattern = {
-        Type = "rings",
-        Rings = {
-            {
-                Count = 1,
-                SpreadX = 0,
-                SpreadY = 0,
-                ThetaMult = 1,
-                ThetaAdd = math.rad( 0 ),
-            },
-            {
-                Count = 4,
-                SpreadX = spreadMax * 1 / 3,
-                SpreadY = spreadMax * 1 / 3,
-                ThetaMult = 1,
-                ThetaAdd = math.rad( 0 ),
-            },
-            {
-                Count = 6,
-                SpreadX = spreadMax * 2 / 3,
-                SpreadY = spreadMax * 2 / 3,
-                ThetaMult = 1,
-                ThetaAdd = math.rad( 0 ),
-            },
-            {
-                Count = 9,
-                SpreadX = spreadMax * 3 / 3,
-                SpreadY = spreadMax * 3 / 3,
-                ThetaMult = 1,
-                ThetaAdd = math.rad( 90 ),
-            },
-        }
-    },
-
     Sound = "CFCBonkShotgun.Single", -- Firing sound (OVERRIDDEN BY SWEP:EmitFireSound)
     TracerName = "Tracer", -- Tracer effect, leave blank for no tracer
+}
+
+local spreadMax = 0.04
+SWEP.Primary.SpreadPattern = {
+    Type = "rings",
+    Rings = {
+        {
+            Count = 1,
+            SpreadX = 0,
+            SpreadY = 0,
+            ThetaMult = 1,
+            ThetaAdd = math.rad( 0 ),
+        },
+        {
+            Count = 4,
+            SpreadX = spreadMax * 1 / 3,
+            SpreadY = spreadMax * 1 / 3,
+            ThetaMult = 1,
+            ThetaAdd = math.rad( 0 ),
+        },
+        {
+            Count = 6,
+            SpreadX = spreadMax * 2 / 3,
+            SpreadY = spreadMax * 2 / 3,
+            ThetaMult = 1,
+            ThetaAdd = math.rad( 0 ),
+        },
+        {
+            Count = 9,
+            SpreadX = spreadMax * 3 / 3,
+            SpreadY = spreadMax * 3 / 3,
+            ThetaMult = 1,
+            ThetaAdd = math.rad( 90 ),
+        },
+    }
 }
 
 SWEP.CFC_FirstTimeHints = {

--- a/lua/weapons/cfc_bonk_shotgun/shared.lua
+++ b/lua/weapons/cfc_bonk_shotgun/shared.lua
@@ -27,7 +27,7 @@ SWEP.CustomHoldType = {} -- Allows you to override any hold type animations with
 
 SWEP.Firemode = 0 -- The default firemode, -1 = full-auto, 0 = semi-auto, >1 = burst fire
 
-local spreadMax = 0.03
+local spreadMax = 0.04
 
 SWEP.Primary = {
     Ammo = "Buckshot", -- The ammo type used when reloading

--- a/lua/weapons/cfc_bonk_shotgun/shared.lua
+++ b/lua/weapons/cfc_bonk_shotgun/shared.lua
@@ -88,7 +88,7 @@ SWEP.Primary.SpreadPattern = {
         {
             Count = 6,
             SpreadX = spreadMax * 2 / 3,
-            SpreadY = spreadMax * 2 / 3,
+            SpreadY = spreadMax * 2 / 3 * 0.8,
             ThetaMult = 1,
             ThetaAdd = math.rad( 0 ),
         },

--- a/lua/weapons/cfc_bonk_shotgun/shared.lua
+++ b/lua/weapons/cfc_bonk_shotgun/shared.lua
@@ -27,6 +27,8 @@ SWEP.CustomHoldType = {} -- Allows you to override any hold type animations with
 
 SWEP.Firemode = 0 -- The default firemode, -1 = full-auto, 0 = semi-auto, >1 = burst fire
 
+local spreadMax = 0.03
+
 SWEP.Primary = {
     Ammo = "Buckshot", -- The ammo type used when reloading
     Cost = 1, -- The amount of ammo used per shot
@@ -74,25 +76,25 @@ SWEP.Primary = {
                 ThetaAdd = math.rad( 0 ),
             },
             {
-                Count = 3,
-                SpreadX = 0.01,
-                SpreadY = 0.01,
+                Count = 4,
+                SpreadX = spreadMax * 1 / 3,
+                SpreadY = spreadMax * 1 / 3,
                 ThetaMult = 1,
-                ThetaAdd = math.rad( -30 ),
+                ThetaAdd = math.rad( 0 ),
             },
             {
                 Count = 6,
-                SpreadX = 0.01 * 2,
-                SpreadY = 0.01 * 2,
+                SpreadX = spreadMax * 2 / 3,
+                SpreadY = spreadMax * 2 / 3,
                 ThetaMult = 1,
                 ThetaAdd = math.rad( 0 ),
             },
             {
-                Count = 10,
-                SpreadX = 0.01 * 3,
-                SpreadY = 0.01 * 3,
+                Count = 9,
+                SpreadX = spreadMax * 3 / 3,
+                SpreadY = spreadMax * 3 / 3,
                 ThetaMult = 1,
-                ThetaAdd = math.rad( 0 ),
+                ThetaAdd = math.rad( 90 ),
             },
         }
     },


### PR DESCRIPTION
- Fixes clientside movement prediction during bonk stun
- Adds a soft blue vignette while bonk stunned, mainly as an indicator that you were launched by a bonk gun
- Impacts with the floor do significantly less damage, putting the focus back onto hitting people into walls
- Bonk Shotgun spread pattern is slightly more focused on the center
- A handful of small nerfs to the Bonk Shotgun's stats, removing the weapon's crutches now that it's more reliable and consistent