### PR TITLE
Don't use :SetCreator()

### DIFF
--- a/lua/entities/cfc_rotten_tomato_projectile/init.lua
+++ b/lua/entities/cfc_rotten_tomato_projectile/init.lua
@@ -84,7 +84,7 @@ function ENT:Touch( ent )
 
     self.Projectile_Hit = true
 
-    local attacker = IsValid( self:GetThrower() ) and self:GetThrower() or self:GetCreator()
+    local attacker = IsValid( self:GetThrower() ) and self:GetThrower()
     if not IsValid( attacker ) then
         attacker = self
     end

--- a/lua/weapons/cfc_simple_base_throwing.lua
+++ b/lua/weapons/cfc_simple_base_throwing.lua
@@ -262,7 +262,6 @@ if SERVER then
         local ply = self:GetOwner()
 
         ent:SetOwner( ply )
-        ent:SetCreator( ply )
 
         self:SetThrowableInHand( false )
 


### PR DESCRIPTION
Don't use `:SetCreator()` on throwables, as that causes [FPP to then set the CPPI owner](https://github.com/CFC-Servers/Falcos-Prop-protection/blob/f65becfc07b53b3acecbda500f1a85e9346a9f74/lua/fpp/server/core.lua#L94-L100) and the value is otherwise unused.